### PR TITLE
Make wrappable by compound content types

### DIFF
--- a/image-multiple-hotspot-question.css
+++ b/image-multiple-hotspot-question.css
@@ -9,10 +9,13 @@
 }
 
 .h5p-image-hotspot-question .image-wrapper {
-  display: inline-block;
   position: relative;
   overflow: hidden;
-  height: 100%;
+}
+
+.h5p-image-hotspot-question .hotspot-image {
+  vertical-align: top;
+  width: 100%;
 }
 
 .h5p-image-hotspot-question .h5peditor .file img {
@@ -120,8 +123,7 @@
 }
 
 .h5p-image-hotspot-question .h5p-question-content {
-  margin-left: 0;
-  margin-right: 0;
+  margin: 0;
 }
 
 @keyframes fade-in {

--- a/image-multiple-hotspot-question.js
+++ b/image-multiple-hotspot-question.js
@@ -130,9 +130,6 @@ H5P.ImageMultipleHotspotQuestion = (function ($, Question) {
 
     this.$wrapper = $('<div>', {
       'class': 'image-hotspot-question ' + this.contentId
-    }).ready(function () {
-      var imageHeight = self.$wrapper.width() * (self.imageSettings.height / self.imageSettings.width);
-      self.$wrapper.css('height', imageHeight + 'px');
     });
 
     this.$imageWrapper = $('<div>', {
@@ -147,7 +144,7 @@ H5P.ImageMultipleHotspotQuestion = (function ($, Question) {
 
     this.$img = $('<img>', {
       'class': 'hotspot-image',
-      'src': H5P.getPath(this.imageSettings.path, this.contentId)
+      'src': (this.imageSettings.path !== '') ? H5P.getPath(this.imageSettings.path, this.contentId) : ''
     });
 
     // Resize image once loaded
@@ -414,46 +411,8 @@ H5P.ImageMultipleHotspotQuestion = (function ($, Question) {
    * Resize image and wrapper
    */
    ImageMultipleHotspotQuestion.prototype.resize = function () {
-    this.resizeImage();
     this.resizeHotspotFeedback();
     this.resizeCorrectHotspotFeedback();
-  };
-
-  /**
-   * Resize image to fit parent width.
-   */
-   ImageMultipleHotspotQuestion.prototype.resizeImage = function () {
-    var self = this;
-
-    // Check that question has been attached
-    if (!(this.$wrapper && this.$img)) {
-      return;
-    }
-
-    // Resize image to fit new container width.
-    var parentWidth = this.$wrapper.width();
-    this.$img.width(parentWidth);
-
-    // Find required height for new width.
-    var naturalWidth = this.$img.get(0).naturalWidth;
-    var naturalHeight = this.$img.get(0).naturalHeight;
-    var imageRatio = naturalHeight / naturalWidth;
-    var neededHeight = -1;
-    if (parentWidth < naturalWidth) {
-      // Scale image down
-      neededHeight = parentWidth * imageRatio;
-    } else {
-      // Scale image to natural size
-      this.$img.width(naturalWidth);
-      neededHeight = naturalHeight;
-    }
-
-    if (neededHeight !== -1) {
-      this.$img.height(neededHeight);
-
-      // Resize wrapper to match image.
-      self.$wrapper.height(neededHeight);
-    }
   };
 
   /**


### PR DESCRIPTION
The content type was not fit to be potentially included in compound content types such as Course Presentation, because in the editor the required wrapper was not set for resizing the images - which can be left to CSS anyway.

When merged in, Find multiple hotspots can be included in content types such as Course Presentation.

- Leave image resizing to stylesheet
- Adjust stylesheet
- Remove code that became unnecessary
- Fix call to empty image path