### PR TITLE
Fix reporting completion prematurely

### DIFF
--- a/image-multiple-hotspot-question.js
+++ b/image-multiple-hotspot-question.js
@@ -346,7 +346,7 @@ H5P.ImageMultipleHotspotQuestion = (function ($, Question) {
     this.hotspotFeedback.$element.addClass('fade-in');
 
     // Trigger xAPI completed event
-    this.triggerXAPIScored(this.getScore(), this.getMaxScore(), 'answered');
+    this.triggerXAPIScored(this.getScore(), this.getMaxScore(), 'answered', this.maxScore === this.getScore());
   };
 
   /**


### PR DESCRIPTION
The content type currently sets the `completion` property of xAPI unconditionally even if the required number of hotspots has not been found yet.

Please cmp. the bug report information at https://h5p.org/node/1265399 and https://wplms.io/support/forums/topic/h5p-quiz-ends-abruptly/ https://prnt.sc/pWse05Ucn9BZ